### PR TITLE
fix some quirks with GVFS

### DIFF
--- a/djangodav/utils.py
+++ b/djangodav/utils.py
@@ -59,7 +59,8 @@ def get_property_tag(res, name):
             return D(name, D.collection)
         return D(name)
     try:
-        return D(name, unicode(getattr(res, name)))
+        if getattr(res, name):
+            return D(name, unicode(getattr(res, name)))
     except AttributeError:
         return
 

--- a/djangodav/views/views.py
+++ b/djangodav/views/views.py
@@ -36,13 +36,18 @@ class DavView(View):
 
     @method_decorator(csrf_exempt)
     def dispatch(self, request, path, *args, **kwargs):
-        self.path = path
-        self.base_url = request.META['PATH_INFO'][:-len(self.path)]
+        if path:
+            self.path = path
+            self.base_url = request.META['PATH_INFO'][:-len(self.path)]
+        else:
+            self.path = '/'
+            self.base_url = request.META['PATH_INFO']
 
         meta = request.META.get
         self.xbody = kwargs['xbody'] = None
         if (request.method.lower() != 'put'
             and meta('CONTENT_TYPE', '').startswith('text/xml')
+            and meta('CONTENT_LENGTH', 0) != ''
             and int(meta('CONTENT_LENGTH', 0)) > 0):
             self.xbody = kwargs['xbody'] = etree.XPathDocumentEvaluator(
                 etree.parse(request, etree.XMLParser(ns_clean=True)),


### PR DESCRIPTION
This patch addresses some issues I've seen with GVFS (gnome dav:// location), and other clients:
- if DAV resource is called without trailing slash, `path` will be `None` in `dispatch()`. This must be handled explicitely so `self.path` and `self.base_url` still have the correct values
- returning `<displayname>None</displayname>` on root confuses GVFS. Better not send any display name at all, if it is undefined (that's what SabreDAV does, for example).
- (broken) clients sometimes send `ContentLength:` header (with empty string). Though this is probably not RFC-conformant, it is not necessary to respond with Error 500 (caused by calling `int('')`).
