### PR TITLE
python 3 compatibility

### DIFF
--- a/djangodav/base/resources.py
+++ b/djangodav/base/resources.py
@@ -21,6 +21,7 @@
 from hashlib import md5
 from mimetypes import guess_type
 
+from django.utils.encoding import force_bytes
 from django.utils.http import urlquote
 from djangodav.utils import rfc3339_date, rfc1123_date, safe_join
 
@@ -191,8 +192,8 @@ class MetaEtagMixIn(object):
         file system. The etag is used to detect changes to a resource between HTTP calls. So this
         needs to change if a resource is modified."""
         hashsum = md5()
-        hashsum.update(self.displayname)
-        hashsum.update(str(self.creationdate))
-        hashsum.update(str(self.getlastmodified))
-        hashsum.update(str(self.getcontentlength))
+        hashsum.update(force_bytes(self.displayname))
+        hashsum.update(force_bytes(self.creationdate))
+        hashsum.update(force_bytes(self.getlastmodified))
+        hashsum.update(force_bytes(self.getcontentlength))
         return hashsum.hexdigest()

--- a/djangodav/fs/resources.py
+++ b/djangodav/fs/resources.py
@@ -117,13 +117,13 @@ class BaseFSDavResource(BaseDavResource):
 
 class DummyReadFSDavResource(BaseFSDavResource):
     def read(self):
-        with open(self.get_abs_path(), 'r') as f:
+        with open(self.get_abs_path(), 'rb') as f:
             return f.read()
 
 
 class DummyWriteFSDavResource(BaseFSDavResource):
     def write(self, request):
-        with file(self.get_abs_path(), 'w') as dst:
+        with open(self.get_abs_path(), 'wb') as dst:
             shutil.copyfileobj(request, dst)
 
 

--- a/djangodav/locks.py
+++ b/djangodav/locks.py
@@ -20,6 +20,7 @@
 # along with DjangoDav.  If not, see <http://www.gnu.org/licenses/>.
 from uuid import uuid4
 
+from django.utils.encoding import force_text
 from djangodav.base.locks import BaseLock
 
 
@@ -28,7 +29,7 @@ class DummyLock(BaseLock):
         pass
 
     def acquire(self, *args, **kwargs):
-        return unicode(uuid4())
+        return force_text(uuid4())
 
     def release(self, token):
         return True

--- a/djangodav/utils.py
+++ b/djangodav/utils.py
@@ -22,6 +22,8 @@
 
 import datetime, time, calendar
 from wsgiref.handlers import format_date_time
+
+from django.utils.encoding import force_text
 from django.utils.feedgenerator import rfc2822_date
 
 try:
@@ -61,7 +63,7 @@ def get_property_tag(res, name):
         return D(name)
     try:
         if hasattr(res, name):
-            return D(name, unicode(getattr(res, name)))
+            return D(name, force_text(getattr(res, name)))
     except AttributeError:
         return
 

--- a/djangodav/views/views.py
+++ b/djangodav/views/views.py
@@ -1,4 +1,7 @@
 import urllib, re
+
+from django.utils.encoding import force_text
+
 try:
     import urlparse
 except ImportError:
@@ -15,6 +18,7 @@ from django.utils.http import parse_etags
 from django.shortcuts import render_to_response
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import View
+from django.utils import six
 
 from djangodav.responses import ResponseException, HttpResponsePreconditionFailed, HttpResponseCreated, HttpResponseNoContent, \
     HttpResponseConflict, HttpResponseMediatypeNotSupported, HttpResponseBadGateway, \
@@ -247,7 +251,13 @@ class DavView(View):
             raise Http404("Resource doesn't exists")
         if not self.has_access(self.resource, 'read'):
             return self.no_access()
-        dst = urlparse.unquote(request.META.get('HTTP_DESTINATION', '')).decode(self.xml_encoding)
+        if six.PY2:
+            # in Python 2.6, urlparse requires bytestrings
+            dst = urlparse.unquote(request.META.get('HTTP_DESTINATION', '')).decode(self.xml_encoding)
+        else:
+            # in Python 3, urlparse understands string
+            dst = urlparse.unquote(request.META.get('HTTP_DESTINATION', ''))
+
         if not dst:
             return HttpResponseBadRequest('Destination header missing.')
         dparts = urlparse.urlparse(dst)
@@ -339,7 +349,7 @@ class DavView(View):
         body = D.activelock(*([
             D.locktype(locktype_obj),
             D.lockscope(lockscope_obj),
-            D.depth(unicode(depth)),
+            D.depth(force_text(depth)),
             D.timeout("Second-%s" % timeout),
             D.locktoken(D.href('opaquelocktoken:%s' % token))]
             + ([owner_obj] if owner_obj is not None else [])


### PR DESCRIPTION
Make djangodav compatible with Python 3. Tested with [litmus](https://github.com/tolsen/litmus) on Python 3.5.2 / Ubuntu 16.04, which at least now does not cause python3-related exceptions any more.