### PR TITLE
add args, kwargs to move and copy, to make custom view kwargs work

### DIFF
--- a/djangodav/views/views.py
+++ b/djangodav/views/views.py
@@ -278,13 +278,13 @@ class DavView(View):
             return HttpResponseNoContent()
         return HttpResponseCreated()
 
-    def copy(self, request, path, xbody):
+    def copy(self, request, path, xbody, *args, **kwargs):
         depth = self.get_depth()
         if depth != -1:
             return HttpResponseBadRequest()
         return self.relocate(request, path, 'copy', depth=depth)
 
-    def move(self, request, path, xbody):
+    def move(self, request, path, xbody, *args, **kwargs):
         if not self.has_access(self.resource, 'delete'):
             return self.no_access()
         return self.relocate(request, path, 'move')


### PR DESCRIPTION
In my scenario, I need to pass an additional kwarg parameter to DavView like this:

```python
# urls.py
urlpatterns = [
  # ...
  url(r'^dav/(?P<domain>[^/]+)/(?P<path>.*)$', AssetDavView.as_view()),
  # ...
]
```

This works out of the box for most DAV operations, but not for copy and move. Patch adds *args, **kwargs to those methods, too, in order to fix that.