### PR TITLE
compatibility patch for use with https://github.com/perry-mitchell/we…

### DIFF
--- a/djangodav/base/resources.py
+++ b/djangodav/base/resources.py
@@ -70,7 +70,7 @@ class BaseDavResource(object):
         # If depth is less than 0, then it started out as -1.
         # We need to keep recursing until we hit 0, or forever
         # in case of infinity.
-        if depth != 0:
+        if depth != 0 and self.is_collection:
             for child in self.get_children():
                 for desc in child.get_descendants(depth=depth-1, include_self=True):
                     yield desc

--- a/djangodav/views/views.py
+++ b/djangodav/views/views.py
@@ -53,14 +53,17 @@ class DavView(View):
 
         meta = request.META.get
         self.xbody = kwargs['xbody'] = None
-        if (request.method.lower() != 'put'
-            and "/xml" in meta('CONTENT_TYPE', '')
-            and meta('CONTENT_LENGTH', 0) != ''
-            and int(meta('CONTENT_LENGTH', 0)) > 0):
-            self.xbody = kwargs['xbody'] = etree.XPathDocumentEvaluator(
-                etree.parse(request, etree.XMLParser(ns_clean=True)),
-                namespaces=WEBDAV_NSMAP
-            )
+        try:
+            if (request.method.lower() != 'put'
+                # and "/xml" in meta('CONTENT_TYPE', '')
+                and meta('CONTENT_LENGTH', 0) != ''
+                and int(meta('CONTENT_LENGTH', 0)) > 0):
+                self.xbody = kwargs['xbody'] = etree.XPathDocumentEvaluator(
+                    etree.parse(request, etree.XMLParser(ns_clean=True)),
+                    namespaces=WEBDAV_NSMAP
+                )
+        except etree.ParseError:
+            return HttpResponseBadRequest("invalid XML in body")
 
         if request.method.upper() in self._allowed_methods():
             handler = getattr(self, request.method.lower(), self.http_method_not_allowed)


### PR DESCRIPTION
First change prevents Error 500 when executing PROPFIND with depth=1. Second change tries to parse body even if content type is not set correctly; additionally we return HTTP 400 if body is malformed (instead of 500).